### PR TITLE
Add not owned file checker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,22 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -213,12 +229,21 @@
   revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
   version = "v1.4.0"
 
+[[projects]]
+  branch = "v2"
+  digest = "1:64b89d4c768e5c183db0dae85ce2f30009d1a1053b915d6d83426304a17849da"
+  name = "gopkg.in/pipe.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3c2ca4d525447ec8b2f606a6974f9c9f40831f26"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/fatih/color",
     "github.com/google/go-github/github",
+    "github.com/hashicorp/go-multierror",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/spf13/afero",
@@ -227,6 +252,7 @@
     "github.com/vrischmann/envconfig",
     "golang.org/x/oauth2",
     "golang.org/x/tools/cmd/goimports",
+    "gopkg.in/pipe.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 The Codeowners Validator project validates the GitHub [CODEOWNERS](https://help.github.com/articles/about-code-owners/) file. It supports private GitHub repositories and GitHub Enterprise installations.
 
 Executed checks:
-* [ ] Find unowned files (owners not specified for given files) (PR: [#8](https://github.com/mszostok/codeowners-validator/pull/8))
+* [x] [EXPERIMENTAL] Find unowned files (owners not specified for given files)
 * [x] Find duplicated patterns
 * [x] Find files/directories that do not exist in a given repository
 * [x] Validate owners:
@@ -33,10 +33,11 @@ Use the following environment variables to configure the application:
 | **GITHUB_ACCESS_TOKEN** | No | | The GitHub access token. Instruction for creating token can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token). If not provided then validating owners functionality could not work properly, e.g. you can reach the API calls quota or if you are setting GitHub Enterprise base URL then an unauthorized error can occur. |
 | **GITHUB_BASE_URL** | No | https://api.github.com/ | The GitHub base URL for API requests. Defaults to the public GitHub API, but can be set to a domain endpoint to use with GitHub Enterprise. |
 | **GITHUB_UPLOAD_URL** | No | https://uploads.github.com/ | The GitHub upload URL for uploading files. <br> <br>It is taken into account only when the `GITHUB_BASE_URL` is also set. If only the `GITHUB_BASE_URL` is provided then this parameter defaults to the `GITHUB_BASE_URL` value. |
+| **CHECKS** | No | - |  The list of checks that will be executed. By default the all checks are executed. Possible values: `files`,`owner`,`duppattern` |
+| **EXPERIMENTAL_CHECKS** | No | - | The comma separated list of experimental checks that should be executed. By default all experimental checks are turn off. Possible values: `owners`.|
 | **CHECK_FAILURE_LEVEL** | No | `warning` | Defines the level on which the application should treat check issues as failures. Defaults to `warning`, which treats both errors and warnings as failures, and exits with error code 3. Possible values are: `error` and `warning`. |
 | **OWNER_CHECKER_ORGANIZATION_NAME** | Yes | | The organization name where the repository is created. Used to check if GitHub owner is in the given organization. |
-| **CHECKS** | No | `files,owners` |  The list of checks that will be executed. By default the both checks will be executed. |
-
+| **NOT_OWNED_CHECKER_SKIP_PATTERNS** | No | - | The comma-separated list of patterns that should be ignored by `not-owned-checker`. For example, you can specify `*` and as a result, the `*` pattern from the **CODEOWNERS** file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. `*       @global-owner1 @global-owner2` |
 
 ### Exit status codes
 

--- a/internal/check/api.go
+++ b/internal/check/api.go
@@ -72,7 +72,7 @@ func (out *Output) ReportIssue(msg string, opts ...Opt) Issue {
 type SeverityType int
 
 const (
-	Error SeverityType = iota
+	Error SeverityType = iota + 1
 	Warning
 )
 

--- a/internal/check/not_owned_file.go
+++ b/internal/check/not_owned_file.go
@@ -1,0 +1,200 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/mszostok/codeowners-validator/pkg/codeowners"
+	"github.com/pkg/errors"
+	"gopkg.in/pipe.v2"
+
+	ctxutil "github.com/mszostok/codeowners-validator/internal/context"
+)
+
+type NotOwnedFileCheckerConfig struct {
+	SkipPatterns []string `envconfig:"optional"`
+}
+
+type NotOwnedFileChecker struct {
+	skipPatterns map[string]struct{}
+}
+
+func NewNotOwnedFile(cfg NotOwnedFileCheckerConfig) *NotOwnedFileChecker {
+	skip := map[string]struct{}{}
+	for _, p := range cfg.SkipPatterns {
+		skip[p] = struct{}{}
+	}
+
+	return &NotOwnedFileChecker{
+		skipPatterns: skip,
+	}
+}
+
+func (c *NotOwnedFileChecker) Check(ctx context.Context, in Input) (output Output, err error) {
+	patterns, err := c.patternsToBeIgnored(ctx, in.CodeownerEntries)
+	if err != nil {
+		return Output{}, err
+	}
+
+	err = c.GitCheckStatus(in.RepoDir)
+	if err != nil {
+		return Output{}, err
+	}
+
+	defer func() {
+		errReset := c.GitResetCurrentBranch(in.RepoDir)
+		if err != nil {
+			output = Output{}
+			err = multierror.Append(err, errReset).ErrorOrNil()
+		}
+	}()
+
+	err = c.AppendToGitignoreFile(in.RepoDir, patterns)
+	if err != nil {
+		return Output{}, err
+	}
+
+	err = c.GitRemoveIgnoredFiles(in.RepoDir)
+	if err != nil {
+		return Output{}, err
+	}
+
+	out, err := c.GitListFiles(in.RepoDir)
+	if err != nil {
+		return Output{}, err
+	}
+
+	lsOut := strings.TrimSpace(out)
+	if lsOut != "" {
+		lines := strings.Split(lsOut, "\n")
+		msg := fmt.Sprintf("Found %d not owned files (skipped patterns: %q): \n%s", len(lines), c.skipPatternsList(), c.ListFormatFunc(lines))
+		output.ReportIssue(msg, WithSeverity(Warning))
+	}
+
+	return output, nil
+}
+
+func (c *NotOwnedFileChecker) patternsToBeIgnored(ctx context.Context, entries []codeowners.Entry) ([]string, error) {
+	var patterns []string
+	for _, entry := range entries {
+		if ctxutil.ShouldExit(ctx) {
+			return []string{}, ctx.Err()
+		}
+
+		if _, found := c.skipPatterns[entry.Pattern]; found {
+			continue
+		}
+		patterns = append(patterns, entry.Pattern)
+	}
+
+	return patterns, nil
+}
+
+func (c *NotOwnedFileChecker) AppendToGitignoreFile(repoDir string, patterns []string) error {
+	f, err := os.OpenFile(path.Join(repoDir, ".gitignore"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	content := strings.Builder{}
+	for _, p := range patterns {
+		content.WriteString(fmt.Sprintf("%s\n", p))
+	}
+
+	_, err = f.WriteString(content.String())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *NotOwnedFileChecker) GitRemoveIgnoredFiles(repoDir string) error {
+	gitrm := pipe.Script(
+		pipe.ChDir(repoDir),
+		pipe.Line(
+			pipe.Exec("git", "ls-files", "-ci", "--exclude-standard", "-z"),
+			pipe.Exec("xargs", "-0", "git", "rm", "--cached"),
+		),
+	)
+
+	_, stderr, err := pipe.DividedOutput(gitrm)
+	if err != nil {
+		return errors.Wrap(err, string(stderr))
+	}
+	return nil
+}
+
+func (c *NotOwnedFileChecker) GitCheckStatus(repoDir string) error {
+	gitstate := pipe.Script(
+		pipe.ChDir(repoDir),
+		pipe.Exec("git", "status", "--porcelain"),
+	)
+
+	out, stderr, err := pipe.DividedOutput(gitstate)
+	if err != nil {
+		return errors.Wrap(err, string(stderr))
+	}
+
+	if string(out) != "" {
+		return fmt.Errorf("git state is dirty: commit all changes before executing %q", c.Name())
+	}
+
+	return nil
+}
+
+func (c *NotOwnedFileChecker) GitResetCurrentBranch(repoDir string) error {
+	gitreset := pipe.Script(
+		pipe.ChDir(repoDir),
+		pipe.Exec("git", "reset", "--hard"),
+	)
+	_, stderr, err := pipe.DividedOutput(gitreset)
+	if err != nil {
+		return errors.Wrap(err, string(stderr))
+	}
+	return nil
+}
+
+func (c *NotOwnedFileChecker) GitListFiles(repoDir string) (string, error) {
+	gitls := pipe.Script(
+		pipe.ChDir(repoDir),
+		pipe.Exec("git", "ls-files"),
+	)
+
+	stdout, stderr, err := pipe.DividedOutput(gitls)
+	if err != nil {
+		return "", errors.Wrap(err, string(stderr))
+	}
+
+	return string(stdout), nil
+}
+
+func (c *NotOwnedFileChecker) skipPatternsList() string {
+	list := make([]string, 0, len(c.skipPatterns))
+	for k := range c.skipPatterns {
+		list = append(list, k)
+	}
+	return strings.Join(list, ",")
+}
+
+// ListFormatFunc is a basic formatter that outputs
+// a bullet point list of the pattern.
+func (c *NotOwnedFileChecker) ListFormatFunc(es []string) string {
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = fmt.Sprintf("            * %s", err)
+	}
+
+	return strings.Join(points, "\n")
+}
+
+// Name returns human readable name of the validator
+func (NotOwnedFileChecker) Name() string {
+	return "[Experimental] Not Owned File Checker"
+}

--- a/vendor/github.com/hashicorp/errwrap/LICENSE
+++ b/vendor/github.com/hashicorp/errwrap/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/errwrap/README.md
+++ b/vendor/github.com/hashicorp/errwrap/README.md
@@ -1,0 +1,89 @@
+# errwrap
+
+`errwrap` is a package for Go that formalizes the pattern of wrapping errors
+and checking if an error contains another error.
+
+There is a common pattern in Go of taking a returned `error` value and
+then wrapping it (such as with `fmt.Errorf`) before returning it. The problem
+with this pattern is that you completely lose the original `error` structure.
+
+Arguably the _correct_ approach is that you should make a custom structure
+implementing the `error` interface, and have the original error as a field
+on that structure, such [as this example](http://golang.org/pkg/os/#PathError).
+This is a good approach, but you have to know the entire chain of possible
+rewrapping that happens, when you might just care about one.
+
+`errwrap` formalizes this pattern (it doesn't matter what approach you use
+above) by giving a single interface for wrapping errors, checking if a specific
+error is wrapped, and extracting that error.
+
+## Installation and Docs
+
+Install using `go get github.com/hashicorp/errwrap`.
+
+Full documentation is available at
+http://godoc.org/github.com/hashicorp/errwrap
+
+## Usage
+
+#### Basic Usage
+
+Below is a very basic example of its usage:
+
+```go
+// A function that always returns an error, but wraps it, like a real
+// function might.
+func tryOpen() error {
+	_, err := os.Open("/i/dont/exist")
+	if err != nil {
+		return errwrap.Wrapf("Doesn't exist: {{err}}", err)
+	}
+
+	return nil
+}
+
+func main() {
+	err := tryOpen()
+
+	// We can use the Contains helpers to check if an error contains
+	// another error. It is safe to do this with a nil error, or with
+	// an error that doesn't even use the errwrap package.
+	if errwrap.Contains(err, "does not exist") {
+		// Do something
+	}
+	if errwrap.ContainsType(err, new(os.PathError)) {
+		// Do something
+	}
+
+	// Or we can use the associated `Get` functions to just extract
+	// a specific error. This would return nil if that specific error doesn't
+	// exist.
+	perr := errwrap.GetType(err, new(os.PathError))
+}
+```
+
+#### Custom Types
+
+If you're already making custom types that properly wrap errors, then
+you can get all the functionality of `errwraps.Contains` and such by
+implementing the `Wrapper` interface with just one function. Example:
+
+```go
+type AppError {
+  Code ErrorCode
+  Err  error
+}
+
+func (e *AppError) WrappedErrors() []error {
+  return []error{e.Err}
+}
+```
+
+Now this works:
+
+```go
+err := &AppError{Err: fmt.Errorf("an error")}
+if errwrap.ContainsType(err, fmt.Errorf("")) {
+	// This will work!
+}
+```

--- a/vendor/github.com/hashicorp/errwrap/errwrap.go
+++ b/vendor/github.com/hashicorp/errwrap/errwrap.go
@@ -1,0 +1,169 @@
+// Package errwrap implements methods to formalize error wrapping in Go.
+//
+// All of the top-level functions that take an `error` are built to be able
+// to take any error, not just wrapped errors. This allows you to use errwrap
+// without having to type-check and type-cast everywhere.
+package errwrap
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+)
+
+// WalkFunc is the callback called for Walk.
+type WalkFunc func(error)
+
+// Wrapper is an interface that can be implemented by custom types to
+// have all the Contains, Get, etc. functions in errwrap work.
+//
+// When Walk reaches a Wrapper, it will call the callback for every
+// wrapped error in addition to the wrapper itself. Since all the top-level
+// functions in errwrap use Walk, this means that all those functions work
+// with your custom type.
+type Wrapper interface {
+	WrappedErrors() []error
+}
+
+// Wrap defines that outer wraps inner, returning an error type that
+// can be cleanly used with the other methods in this package, such as
+// Contains, GetAll, etc.
+//
+// This function won't modify the error message at all (the outer message
+// will be used).
+func Wrap(outer, inner error) error {
+	return &wrappedError{
+		Outer: outer,
+		Inner: inner,
+	}
+}
+
+// Wrapf wraps an error with a formatting message. This is similar to using
+// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap
+// errors, you should replace it with this.
+//
+// format is the format of the error message. The string '{{err}}' will
+// be replaced with the original error message.
+func Wrapf(format string, err error) error {
+	outerMsg := "<nil>"
+	if err != nil {
+		outerMsg = err.Error()
+	}
+
+	outer := errors.New(strings.Replace(
+		format, "{{err}}", outerMsg, -1))
+
+	return Wrap(outer, err)
+}
+
+// Contains checks if the given error contains an error with the
+// message msg. If err is not a wrapped error, this will always return
+// false unless the error itself happens to match this msg.
+func Contains(err error, msg string) bool {
+	return len(GetAll(err, msg)) > 0
+}
+
+// ContainsType checks if the given error contains an error with
+// the same concrete type as v. If err is not a wrapped error, this will
+// check the err itself.
+func ContainsType(err error, v interface{}) bool {
+	return len(GetAllType(err, v)) > 0
+}
+
+// Get is the same as GetAll but returns the deepest matching error.
+func Get(err error, msg string) error {
+	es := GetAll(err, msg)
+	if len(es) > 0 {
+		return es[len(es)-1]
+	}
+
+	return nil
+}
+
+// GetType is the same as GetAllType but returns the deepest matching error.
+func GetType(err error, v interface{}) error {
+	es := GetAllType(err, v)
+	if len(es) > 0 {
+		return es[len(es)-1]
+	}
+
+	return nil
+}
+
+// GetAll gets all the errors that might be wrapped in err with the
+// given message. The order of the errors is such that the outermost
+// matching error (the most recent wrap) is index zero, and so on.
+func GetAll(err error, msg string) []error {
+	var result []error
+
+	Walk(err, func(err error) {
+		if err.Error() == msg {
+			result = append(result, err)
+		}
+	})
+
+	return result
+}
+
+// GetAllType gets all the errors that are the same type as v.
+//
+// The order of the return value is the same as described in GetAll.
+func GetAllType(err error, v interface{}) []error {
+	var result []error
+
+	var search string
+	if v != nil {
+		search = reflect.TypeOf(v).String()
+	}
+	Walk(err, func(err error) {
+		var needle string
+		if err != nil {
+			needle = reflect.TypeOf(err).String()
+		}
+
+		if needle == search {
+			result = append(result, err)
+		}
+	})
+
+	return result
+}
+
+// Walk walks all the wrapped errors in err and calls the callback. If
+// err isn't a wrapped error, this will be called once for err. If err
+// is a wrapped error, the callback will be called for both the wrapper
+// that implements error as well as the wrapped error itself.
+func Walk(err error, cb WalkFunc) {
+	if err == nil {
+		return
+	}
+
+	switch e := err.(type) {
+	case *wrappedError:
+		cb(e.Outer)
+		Walk(e.Inner, cb)
+	case Wrapper:
+		cb(err)
+
+		for _, err := range e.WrappedErrors() {
+			Walk(err, cb)
+		}
+	default:
+		cb(err)
+	}
+}
+
+// wrappedError is an implementation of error that has both the
+// outer and inner errors.
+type wrappedError struct {
+	Outer error
+	Inner error
+}
+
+func (w *wrappedError) Error() string {
+	return w.Outer.Error()
+}
+
+func (w *wrappedError) WrappedErrors() []error {
+	return []error{w.Outer, w.Inner}
+}

--- a/vendor/github.com/hashicorp/errwrap/go.mod
+++ b/vendor/github.com/hashicorp/errwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/errwrap

--- a/vendor/github.com/hashicorp/go-multierror/.travis.yml
+++ b/vendor/github.com/hashicorp/go-multierror/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+
+language: go
+
+go:
+  - 1.x
+
+branches:
+  only:
+    - master
+
+script: make test testrace

--- a/vendor/github.com/hashicorp/go-multierror/LICENSE
+++ b/vendor/github.com/hashicorp/go-multierror/LICENSE
@@ -1,0 +1,353 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/go-multierror/Makefile
+++ b/vendor/github.com/hashicorp/go-multierror/Makefile
@@ -1,0 +1,31 @@
+TEST?=./...
+
+default: test
+
+# test runs the test suite and vets the code.
+test: generate
+	@echo "==> Running tests..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -parallel=10 ${TESTARGS}
+
+# testrace runs the race checker
+testrace: generate
+	@echo "==> Running tests (race)..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -race ${TESTARGS}
+
+# updatedeps installs all the dependencies needed to run and build.
+updatedeps:
+	@sh -c "'${CURDIR}/scripts/deps.sh' '${NAME}'"
+
+# generate runs `go generate` to build the dynamically generated source files.
+generate:
+	@echo "==> Generating..."
+	@find . -type f -name '.DS_Store' -delete
+	@go list ./... \
+		| grep -v "/vendor/" \
+		| xargs -n1 go generate
+
+.PHONY: default test testrace updatedeps generate

--- a/vendor/github.com/hashicorp/go-multierror/README.md
+++ b/vendor/github.com/hashicorp/go-multierror/README.md
@@ -1,0 +1,97 @@
+# go-multierror
+
+[![Build Status](http://img.shields.io/travis/hashicorp/go-multierror.svg?style=flat-square)][travis]
+[![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godocs]
+
+[travis]: https://travis-ci.org/hashicorp/go-multierror
+[godocs]: https://godoc.org/github.com/hashicorp/go-multierror
+
+`go-multierror` is a package for Go that provides a mechanism for
+representing a list of `error` values as a single `error`.
+
+This allows a function in Go to return an `error` that might actually
+be a list of errors. If the caller knows this, they can unwrap the
+list and access the errors. If the caller doesn't know, the error
+formats to a nice human-readable format.
+
+`go-multierror` implements the
+[errwrap](https://github.com/hashicorp/errwrap) interface so that it can
+be used with that library, as well.
+
+## Installation and Docs
+
+Install using `go get github.com/hashicorp/go-multierror`.
+
+Full documentation is available at
+http://godoc.org/github.com/hashicorp/go-multierror
+
+## Usage
+
+go-multierror is easy to use and purposely built to be unobtrusive in
+existing Go applications/libraries that may not be aware of it.
+
+**Building a list of errors**
+
+The `Append` function is used to create a list of errors. This function
+behaves a lot like the Go built-in `append` function: it doesn't matter
+if the first argument is nil, a `multierror.Error`, or any other `error`,
+the function behaves as you would expect.
+
+```go
+var result error
+
+if err := step1(); err != nil {
+	result = multierror.Append(result, err)
+}
+if err := step2(); err != nil {
+	result = multierror.Append(result, err)
+}
+
+return result
+```
+
+**Customizing the formatting of the errors**
+
+By specifying a custom `ErrorFormat`, you can customize the format
+of the `Error() string` function:
+
+```go
+var result *multierror.Error
+
+// ... accumulate errors here, maybe using Append
+
+if result != nil {
+	result.ErrorFormat = func([]error) string {
+		return "errors!"
+	}
+}
+```
+
+**Accessing the list of errors**
+
+`multierror.Error` implements `error` so if the caller doesn't know about
+multierror, it will work just fine. But if you're aware a multierror might
+be returned, you can use type switches to access the list of errors:
+
+```go
+if err := something(); err != nil {
+	if merr, ok := err.(*multierror.Error); ok {
+		// Use merr.Errors
+	}
+}
+```
+
+**Returning a multierror only if there are errors**
+
+If you build a `multierror.Error`, you can use the `ErrorOrNil` function
+to return an `error` implementation only if there are errors to return:
+
+```go
+var result *multierror.Error
+
+// ... accumulate errors here
+
+// Return the `error` only if errors were added to the multierror, otherwise
+// return nil since there are no errors.
+return result.ErrorOrNil()
+```

--- a/vendor/github.com/hashicorp/go-multierror/append.go
+++ b/vendor/github.com/hashicorp/go-multierror/append.go
@@ -1,0 +1,41 @@
+package multierror
+
+// Append is a helper function that will append more errors
+// onto an Error in order to create a larger multi-error.
+//
+// If err is not a multierror.Error, then it will be turned into
+// one. If any of the errs are multierr.Error, they will be flattened
+// one level into err.
+func Append(err error, errs ...error) *Error {
+	switch err := err.(type) {
+	case *Error:
+		// Typed nils can reach here, so initialize if we are nil
+		if err == nil {
+			err = new(Error)
+		}
+
+		// Go through each error and flatten
+		for _, e := range errs {
+			switch e := e.(type) {
+			case *Error:
+				if e != nil {
+					err.Errors = append(err.Errors, e.Errors...)
+				}
+			default:
+				if e != nil {
+					err.Errors = append(err.Errors, e)
+				}
+			}
+		}
+
+		return err
+	default:
+		newErrs := make([]error, 0, len(errs)+1)
+		if err != nil {
+			newErrs = append(newErrs, err)
+		}
+		newErrs = append(newErrs, errs...)
+
+		return Append(&Error{}, newErrs...)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/flatten.go
+++ b/vendor/github.com/hashicorp/go-multierror/flatten.go
@@ -1,0 +1,26 @@
+package multierror
+
+// Flatten flattens the given error, merging any *Errors together into
+// a single *Error.
+func Flatten(err error) error {
+	// If it isn't an *Error, just return the error as-is
+	if _, ok := err.(*Error); !ok {
+		return err
+	}
+
+	// Otherwise, make the result and flatten away!
+	flatErr := new(Error)
+	flatten(err, flatErr)
+	return flatErr
+}
+
+func flatten(err error, flatErr *Error) {
+	switch err := err.(type) {
+	case *Error:
+		for _, e := range err.Errors {
+			flatten(e, flatErr)
+		}
+	default:
+		flatErr.Errors = append(flatErr.Errors, err)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/format.go
+++ b/vendor/github.com/hashicorp/go-multierror/format.go
@@ -1,0 +1,27 @@
+package multierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorFormatFunc is a function callback that is called by Error to
+// turn the list of errors into a string.
+type ErrorFormatFunc func([]error) string
+
+// ListFormatFunc is a basic formatter that outputs the number of errors
+// that occurred along with a bullet point list of the errors.
+func ListFormatFunc(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
+	}
+
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d errors occurred:\n\t%s\n\n",
+		len(es), strings.Join(points, "\n\t"))
+}

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-multierror
+
+require github.com/hashicorp/errwrap v1.0.0

--- a/vendor/github.com/hashicorp/go-multierror/go.sum
+++ b/vendor/github.com/hashicorp/go-multierror/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce h1:prjrVgOk2Yg6w+PflHoszQNLTUh4kaByUcEWM/9uin4=
+github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/vendor/github.com/hashicorp/go-multierror/multierror.go
+++ b/vendor/github.com/hashicorp/go-multierror/multierror.go
@@ -1,0 +1,51 @@
+package multierror
+
+import (
+	"fmt"
+)
+
+// Error is an error type to track multiple errors. This is used to
+// accumulate errors in cases and return them as a single "error".
+type Error struct {
+	Errors      []error
+	ErrorFormat ErrorFormatFunc
+}
+
+func (e *Error) Error() string {
+	fn := e.ErrorFormat
+	if fn == nil {
+		fn = ListFormatFunc
+	}
+
+	return fn(e.Errors)
+}
+
+// ErrorOrNil returns an error interface if this Error represents
+// a list of errors, or returns nil if the list of errors is empty. This
+// function is useful at the end of accumulation to make sure that the value
+// returned represents the existence of errors.
+func (e *Error) ErrorOrNil() error {
+	if e == nil {
+		return nil
+	}
+	if len(e.Errors) == 0 {
+		return nil
+	}
+
+	return e
+}
+
+func (e *Error) GoString() string {
+	return fmt.Sprintf("*%#v", *e)
+}
+
+// WrappedErrors returns the list of errors that this Error is wrapping.
+// It is an implementation of the errwrap.Wrapper interface so that
+// multierror.Error can be used with that library.
+//
+// This method is not safe to be called concurrently and is no different
+// than accessing the Errors field directly. It is implemented only to
+// satisfy the errwrap.Wrapper interface.
+func (e *Error) WrappedErrors() []error {
+	return e.Errors
+}

--- a/vendor/github.com/hashicorp/go-multierror/prefix.go
+++ b/vendor/github.com/hashicorp/go-multierror/prefix.go
@@ -1,0 +1,37 @@
+package multierror
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+)
+
+// Prefix is a helper function that will prefix some text
+// to the given error. If the error is a multierror.Error, then
+// it will be prefixed to each wrapped error.
+//
+// This is useful to use when appending multiple multierrors
+// together in order to give better scoping.
+func Prefix(err error, prefix string) error {
+	if err == nil {
+		return nil
+	}
+
+	format := fmt.Sprintf("%s {{err}}", prefix)
+	switch err := err.(type) {
+	case *Error:
+		// Typed nils can reach here, so initialize if we are nil
+		if err == nil {
+			err = new(Error)
+		}
+
+		// Wrap each of the errors
+		for i, e := range err.Errors {
+			err.Errors[i] = errwrap.Wrapf(format, e)
+		}
+
+		return err
+	default:
+		return errwrap.Wrapf(format, err)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/sort.go
+++ b/vendor/github.com/hashicorp/go-multierror/sort.go
@@ -1,0 +1,16 @@
+package multierror
+
+// Len implements sort.Interface function for length
+func (err Error) Len() int {
+	return len(err.Errors)
+}
+
+// Swap implements sort.Interface function for swapping elements
+func (err Error) Swap(i, j int) {
+	err.Errors[i], err.Errors[j] = err.Errors[j], err.Errors[i]
+}
+
+// Less implements sort.Interface function for determining order
+func (err Error) Less(i, j int) bool {
+	return err.Errors[i].Error() < err.Errors[j].Error()
+}

--- a/vendor/gopkg.in/pipe.v2/LICENSE
+++ b/vendor/gopkg.in/pipe.v2/LICENSE
@@ -1,0 +1,25 @@
+Package pipe implements unix-like pipelines for Go.
+ 
+Copyright (c) 2013-2014 Gustavo Niemeyer <gustavo@niemeyer.net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/gopkg.in/pipe.v2/README.md
+++ b/vendor/gopkg.in/pipe.v2/README.md
@@ -1,0 +1,4 @@
+Installation and usage
+----------------------
+
+See [gopkg.in/pipe.v2](https://gopkg.in/pipe.v2) for documentation and usage details.

--- a/vendor/gopkg.in/pipe.v2/pipe.go
+++ b/vendor/gopkg.in/pipe.v2/pipe.go
@@ -1,0 +1,904 @@
+// pipe - Unix-like pipelines for Go
+//
+// Copyright (c) 2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Package pipe implements unix-like pipelines for Go.
+//
+// See the documentation for details:
+//
+//   http://labix.org/pipe
+//
+package pipe
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// Pipe functions implement arbitrary functionality that may be
+// integrated with pipe scripts and pipelines. Pipe functions
+// must not block reading or writing to the state streams. These
+// operations must be run from a Task.
+type Pipe func(s *State) error
+
+// A Task may be registered by a Pipe into a State to run any
+// activity concurrently with other tasks.
+// Tasks registered within the execution of a Script only run after
+// the preceding entries in the same script have succeeded.
+type Task interface {
+
+	// Run runs the task concurrently with other tasks as appropriate
+	// for the pipe. Run may flow data from the input stream and/or
+	// to the output streams of the pipe, and it must block while doing
+	// so. It must return only after all of its activities have
+	// terminated completely.
+	Run(s *State) error
+
+	// Kill abruptly interrupts in-progress activities being done by Run.
+	// If Run is blocked simply reading from and/or writing to the state
+	// streams, Kill doesn't have to do anything as Run will be unblocked
+	// by the closing of the streams.
+	Kill()
+}
+
+// State defines the environment for Pipe functions to run on.
+// Create a new State via the NewState function.
+type State struct {
+
+	// Stdin, Stdout, and Stderr represent the respective data streams
+	// that the Pipe may act upon. Reading from and/or writing to these
+	// streams must be done from within a Task registered via AddTask.
+	// The three streams are initialized by NewState and must not be nil.
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Dir represents the directory in which all filesystem-related
+	// operations performed by the Pipe must be run on. It defaults
+	// to the current directory, and may be changed by Pipe functions.
+	Dir string
+
+	// Env is the process environment in which all executions performed
+	// by the Pipe must be run on. It defaults to a copy of the
+	// environmnet from the current process, and may be changed by Pipe
+	// functions.
+	Env []string
+
+	// Timeout defines the amount of time to wait before aborting running tasks.
+	// If set to zero, the pipe will not be aborted.
+	Timeout time.Duration
+
+	killedMutex sync.Mutex
+	killedNoted bool
+	killed      chan bool
+
+	pendingTasks []*pendingTask
+}
+
+// NewState returns a new state for running pipes with.
+// The state's Stdout and Stderr are set to the provided streams,
+// Stdin is initialized to an empty reader, and Env is initialized to
+// the environment of the current process.
+func NewState(stdout, stderr io.Writer) *State {
+	if stdout == nil {
+		stdout = ioutil.Discard
+	}
+	if stderr == nil {
+		stderr = ioutil.Discard
+	}
+	return &State{
+		Stdin:  strings.NewReader(""),
+		Stdout: stdout,
+		Stderr: stderr,
+		Env:    os.Environ(),
+		killed: make(chan bool, 1),
+	}
+}
+
+type pendingTask struct {
+	s State
+	t Task
+	c []io.Closer
+
+	wg sync.WaitGroup
+	wt []*pendingTask
+
+	cancel int32
+}
+
+func (pt *pendingTask) closeWhenDone(c io.Closer) {
+	pt.c = append(pt.c, c)
+}
+
+func (pt *pendingTask) waitFor(other *pendingTask) {
+	pt.wg.Add(1)
+	other.wt = append(other.wt, pt)
+}
+
+func (pt *pendingTask) wait() {
+	pt.wg.Wait()
+}
+
+func (pt *pendingTask) done(err error) {
+	for _, c := range pt.c {
+		c.Close()
+	}
+	for _, wt := range pt.wt {
+		if err != nil {
+			atomic.AddInt32(&wt.cancel, 1)
+		}
+		wt.wg.Done()
+	}
+}
+
+var (
+	ErrTimeout = errors.New("timeout")
+	ErrKilled  = errors.New("explicitly killed")
+)
+
+type Errors []error
+
+func (e Errors) Error() string {
+	var errors []string
+	for _, err := range e {
+		errors = append(errors, err.Error())
+	}
+	return strings.Join(errors, "; ")
+}
+
+// AddTask adds t to be run concurrently with other tasks
+// as appropriate for the pipe.
+func (s *State) AddTask(t Task) error {
+	pt := &pendingTask{s: *s, t: t}
+	pt.s.Env = append([]string(nil), s.Env...)
+	s.pendingTasks = append(s.pendingTasks, pt)
+	return nil
+}
+
+
+// RunTasks runs all pending tasks registered via AddTask.
+// This is called by the pipe running functions and generally
+// there's no reason to call it directly.
+func (s *State) RunTasks() error {
+	done := make(chan error, len(s.pendingTasks))
+	for _, f := range s.pendingTasks {
+		go func(pt *pendingTask) {
+			pt.wait()
+			var err error
+			if pt.cancel == 0 {
+				err = pt.t.Run(&pt.s)
+			}
+			pt.done(err)
+			done <- err
+		}(f)
+	}
+
+	var timeout <-chan time.Time
+	if s.Timeout > 0 {
+		timeout = time.After(s.Timeout)
+	}
+
+	var errs Errors
+	var goodErr, badErr bool
+
+	fail := func(err error) {
+		if errs == nil {
+			for _, pt := range s.pendingTasks {
+				pt.t.Kill()
+			}
+		}
+		if errs == nil || errs[len(errs)-1] != ErrTimeout && errs[len(errs)-1] != ErrKilled {
+			errs = append(errs, err)
+			if discardErr(err) {
+				badErr = true
+			} else {
+				goodErr = true
+			}
+		}
+	}
+
+	for _ = range s.pendingTasks {
+		var err error
+		select {
+		case err = <-done:
+		case <-timeout:
+			fail(ErrTimeout)
+			err = <-done
+		case <-s.killed:
+			fail(ErrKilled)
+			err = <-done
+		}
+		if err != nil {
+			fail(err)
+		}
+	}
+	s.pendingTasks = nil
+
+	if errs == nil {
+		return nil
+	}
+
+	if goodErr && badErr {
+		good := 0
+		for _, err := range errs {
+			if !discardErr(err) {
+				errs[good] = err
+				good++
+			}
+		}
+		errs = errs[:good]
+	}
+	return errs
+}
+
+func discardErr(err error) bool {
+	if err == io.ErrClosedPipe {
+		return true
+	}
+	if err1, ok := err.(*execError); ok {
+		if err2, ok := err1.err.(*exec.ExitError); ok {
+			status, ok := err2.Sys().(syscall.WaitStatus)
+			return ok && status.Signaled() && status.Signal() == 9
+		}
+	}
+	return false
+}
+
+// Kill sends a kill notice to all pending tasks.
+func (s *State) Kill() {
+	s.killedMutex.Lock()
+	if !s.killedNoted {
+		s.killedNoted = true
+		s.killed <- true
+	}
+	s.killedMutex.Unlock()
+}
+
+// EnvVar returns the value for the named environment variable in s.
+func (s *State) EnvVar(name string) string {
+	prefix := name + "="
+	for _, kv := range s.Env {
+		if strings.HasPrefix(kv, prefix) {
+			return kv[len(prefix):]
+		}
+	}
+	return ""
+}
+
+// SetEnvVar sets the named environment variable to the given value in s.
+func (s *State) SetEnvVar(name, value string) {
+	prefix := name + "="
+	for i, kv := range s.Env {
+		if strings.HasPrefix(kv, prefix) {
+			s.Env[i] = prefix + value
+			return
+		}
+	}
+	s.Env = append(s.Env, prefix+value)
+}
+
+// Path returns the provided path relative to the state's current directory.
+// If multiple arguments are provided, they're joined via filepath.Join.
+// If path is absolute, it is taken by itself.
+func (s *State) Path(path ...string) string {
+	if len(path) == 0 {
+		return s.Dir
+	}
+	if filepath.IsAbs(path[0]) {
+		return filepath.Join(path...)
+	}
+	if len(path) == 1 {
+		return filepath.Join(s.Dir, path[0])
+	}
+	return filepath.Join(append([]string{s.Dir}, path...)...)
+}
+
+func firstErr(err1, err2 error) error {
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// Run runs the p pipe discarding its output.
+//
+// See functions Output, CombinedOutput, and DividedOutput.
+func Run(p Pipe) error {
+	s := NewState(nil, nil)
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return err
+}
+
+// RunTimeout runs the p pipe discarding its output.
+//
+// The pipe is killed if it takes longer to run than the provided timeout.
+//
+// See functions OutputTimeout, CombinedOutputTimeout, and DividedOutputTimeout.
+func RunTimeout(p Pipe, timeout time.Duration) error {
+	s := NewState(nil, nil)
+	s.Timeout = timeout
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return err
+}
+
+// Output runs the p pipe and returns its stdout output.
+//
+// See functions Run, CombinedOutput, and DividedOutput.
+func Output(p Pipe) ([]byte, error) {
+	outb := &OutputBuffer{}
+	s := NewState(outb, nil)
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), err
+}
+
+// OutputTimeout runs the p pipe and returns its stdout output.
+//
+// The pipe is killed if it takes longer to run than the provided timeout.
+//
+// See functions RunTimeout, CombinedOutputTimeout, and DividedOutputTimeout.
+func OutputTimeout(p Pipe, timeout time.Duration) ([]byte, error) {
+	outb := &OutputBuffer{}
+	s := NewState(outb, nil)
+	s.Timeout = timeout
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), err
+}
+
+// CombinedOutput runs the p pipe and returns its stdout and stderr
+// outputs merged together.
+//
+// See functions Run, Output, and DividedOutput.
+func CombinedOutput(p Pipe) ([]byte, error) {
+	outb := &OutputBuffer{}
+	s := NewState(outb, outb)
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), err
+}
+
+// CombinedOutputTimeout runs the p pipe and returns its stdout and stderr
+// outputs merged together.
+//
+// The pipe is killed if it takes longer to run than the provided timeout.
+//
+// See functions RunTimeout, OutputTimeout, and DividedOutputTimeout.
+func CombinedOutputTimeout(p Pipe, timeout time.Duration) ([]byte, error) {
+	outb := &OutputBuffer{}
+	s := NewState(outb, outb)
+	s.Timeout = timeout
+	err := p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), err
+}
+
+// DividedOutput runs the p pipe and returns its stdout and stderr outputs.
+//
+// See functions Run, Output, and CombinedOutput.
+func DividedOutput(p Pipe) (stdout []byte, stderr []byte, err error) {
+	outb := &OutputBuffer{}
+	errb := &OutputBuffer{}
+	s := NewState(outb, errb)
+	err = p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), errb.Bytes(), err
+}
+
+// DividedOutputTimeout runs the p pipe and returns its stdout and stderr outputs.
+//
+// The pipe is killed if it takes longer to run than the provided timeout.
+//
+// See functions RunTimeout, OutputTimeout, and CombinedOutputTimeout.
+func DividedOutputTimeout(p Pipe, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+	outb := &OutputBuffer{}
+	errb := &OutputBuffer{}
+	s := NewState(outb, errb)
+	s.Timeout = timeout
+	err = p(s)
+	if err == nil {
+		err = s.RunTasks()
+	}
+	return outb.Bytes(), errb.Bytes(), err
+}
+
+// OutputBuffer is a concurrency safe writer that buffers all input.
+//
+// It is used in the implementation of the output functions.
+type OutputBuffer struct {
+	m   sync.Mutex
+	buf []byte
+}
+
+// Writes appends b to out's buffered data.
+func (out *OutputBuffer) Write(b []byte) (n int, err error) {
+	out.m.Lock()
+	out.buf = append(out.buf, b...)
+	out.m.Unlock()
+	return len(b), nil
+}
+
+// Bytes returns all the data written to out.
+func (out *OutputBuffer) Bytes() []byte {
+	out.m.Lock()
+	buf := out.buf
+	out.m.Unlock()
+	return buf
+}
+
+// Exec returns a pipe that runs the named program with the given arguments.
+func Exec(name string, args ...string) Pipe {
+	return func(s *State) error {
+		s.AddTask(&execTask{name: name, args: args})
+		return nil
+	}
+}
+
+// System returns a pipe that runs cmd via a system shell.
+// It is equivalent to the pipe Exec("/bin/sh", "-c", cmd).
+func System(cmd string) Pipe {
+	return Exec("/bin/sh", "-c", cmd)
+}
+
+type execTask struct {
+	name string
+	args []string
+
+	m      sync.Mutex
+	p      *os.Process
+	cancel bool
+}
+
+func (f *execTask) Run(s *State) error {
+	f.m.Lock()
+	if f.cancel {
+		f.m.Unlock()
+		return nil
+	}
+	cmd := exec.Command(f.name, f.args...)
+	cmd.Dir = s.Dir
+	cmd.Env = s.Env
+	cmd.Stdin = s.Stdin
+	cmd.Stdout = s.Stdout
+	cmd.Stderr = s.Stderr
+	err := cmd.Start()
+	f.p = cmd.Process
+	f.m.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return &execError{f.name, err}
+	}
+	return nil
+}
+
+func (f *execTask) Kill() {
+	f.m.Lock()
+	p := f.p
+	f.cancel = true
+	f.m.Unlock()
+	if p != nil {
+		p.Kill()
+	}
+}
+
+type execError struct {
+	name string
+	err  error
+}
+
+func (e *execError) Error() string {
+	return fmt.Sprintf("command %q: %v", e.name, e.err)
+}
+
+// ChDir changes the pipe's current directory. If dir is relative,
+// the change is made relative to the pipe's previous current directory.
+//
+// Other than it being the default current directory for new pipes,
+// the working directory of the running process isn't considered or
+// changed.
+func ChDir(dir string) Pipe {
+	return func(s *State) error {
+		s.Dir = s.Path(dir)
+		return nil
+	}
+}
+
+// MkDir creates dir with the provided perm bits. If dir is relative,
+// the created path is relative to the pipe's current directory.
+func MkDir(dir string, perm os.FileMode) Pipe {
+	return func(s *State) error {
+		return os.Mkdir(s.Path(dir), perm)
+	}
+}
+
+// MkDirAll creates the missing parents of dir and dir itself with the
+// provided perm bits. If dir is relative, the created path is relative
+// to the pipe's current directory.
+func MkDirAll(dir string, perm os.FileMode) Pipe {
+	return func(s *State) error {
+		return os.MkdirAll(s.Path(dir), perm)
+	}
+}
+
+// SetEnvVar sets the value of the named environment variable in the pipe.
+//
+// Other than it being the default for new pipes, the environment of the
+// running process isn't consulted or changed.
+func SetEnvVar(name string, value string) Pipe {
+	return func(s *State) error {
+		s.SetEnvVar(name, value)
+		return nil
+	}
+}
+
+// Line creates a pipeline with the provided entries, where the stdout
+// of entry N in the pipeline is connected to the stdin of entry N+1.
+//
+// For example, the equivalent of "cat article.ps | lpr" is:
+//
+//    p := pipe.Line(
+//        pipe.ReadFile("article.ps"),
+//        pipe.Exec("lpr"),
+//    )
+//    output, err := pipe.CombinedOutput(p)
+//
+func Line(p ...Pipe) Pipe {
+	return func(s *State) error {
+		dir := s.Dir
+		env := s.Env
+		s.Env = append([]string(nil), s.Env...)
+		defer func() {
+			s.Dir = dir
+			s.Env = env
+		}()
+
+		end := len(p) - 1
+		endStdout := s.Stdout
+		var r *io.PipeReader
+		var w *io.PipeWriter
+		for i, p := range p {
+			var closeIn, closeOut *refCloser
+			if r != nil {
+				closeIn = &refCloser{r, 1}
+			}
+			if i == end {
+				r, w = nil, nil
+				s.Stdout = endStdout
+			} else {
+				r, w = io.Pipe()
+				s.Stdout = w
+				closeOut = &refCloser{w, 1}
+			}
+
+			oldLen := len(s.pendingTasks)
+			if err := p(s); err != nil {
+				closeIn.Close()
+				return err
+			}
+			newLen := len(s.pendingTasks)
+
+			for fi := oldLen; fi < newLen; fi++ {
+				pt := s.pendingTasks[fi]
+				if c, ok := pt.s.Stdin.(io.Closer); ok && closeIn.uses(c) {
+					closeIn.refs++
+					pt.closeWhenDone(closeIn)
+				}
+				if c, ok := pt.s.Stdout.(io.Closer); ok && closeOut.uses(c) {
+					closeOut.refs++
+					pt.closeWhenDone(closeOut)
+				}
+				if c, ok := pt.s.Stderr.(io.Closer); ok && closeOut.uses(c) {
+					closeOut.refs++
+					pt.closeWhenDone(closeOut)
+				}
+			}
+			closeIn.Close()
+			closeOut.Close()
+
+			if i < end {
+				s.Stdin = r
+			}
+		}
+		return nil
+	}
+}
+
+type refCloser struct {
+	c    io.Closer
+	refs int32
+}
+
+func (rc *refCloser) uses(c io.Closer) bool {
+	return rc != nil && rc.c == c
+}
+
+func (rc *refCloser) Close() error {
+	if rc != nil && atomic.AddInt32(&rc.refs, -1) == 0 {
+		return rc.c.Close()
+	}
+	return nil
+}
+
+// Script creates a pipe sequence with the provided entries.
+//
+// For example, the equivalent of "cat article.ps | lpr; mv article.ps{,.done}" is:
+//
+//    p := pipe.Script(
+//        pipe.Line(
+//            pipe.ReadFile("article.ps"),
+//            pipe.Exec("lpr"),
+//        ),
+//        pipe.RenameFile("article.ps", "article.ps.done"),
+//    )
+//    output, err := pipe.CombinedOutput(p)
+//
+func Script(p ...Pipe) Pipe {
+	return func(s *State) error {
+		saved := *s
+		s.Env = append([]string(nil), s.Env...)
+		defer func() {
+			s.Dir = saved.Dir
+			s.Env = saved.Env
+		}()
+
+		startLen := len(s.pendingTasks)
+		for _, p := range p {
+			oldLen := len(s.pendingTasks)
+			if err := p(s); err != nil {
+				return err
+			}
+			newLen := len(s.pendingTasks)
+
+			s.Stdin = saved.Stdin
+			s.Stdout = saved.Stdout
+			s.Stderr = saved.Stderr
+
+			for fi := oldLen; fi < newLen; fi++ {
+				for wi := startLen; wi < oldLen; wi++ {
+					s.pendingTasks[fi].waitFor(s.pendingTasks[wi])
+				}
+			}
+		}
+		return nil
+	}
+}
+
+type taskFunc func(s *State) error
+
+func (f taskFunc) Run(s *State) error { return f(s) }
+func (f taskFunc) Kill()              {}
+
+// TaskFunc is a helper to define a Pipe that adds a Task
+// with f as its Run method.
+func TaskFunc(f func(s *State) error) Pipe {
+	return func(s *State) error {
+		s.AddTask(taskFunc(f))
+		return nil
+	}
+}
+
+// Print provides args to fmt.Sprint and writes the resuling
+// string to the pipe's stdout.
+func Print(args ...interface{}) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := s.Stdout.Write([]byte(fmt.Sprint(args...)))
+		return err
+	})
+}
+
+// Println provides args to fmt.Sprintln and writes the resuling
+// string to the pipe's stdout.
+func Println(args ...interface{}) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := s.Stdout.Write([]byte(fmt.Sprintln(args...)))
+		return err
+	})
+}
+
+// Printf provides format and args to fmt.Sprintf and writes
+// the resulting string to the pipe's stdout.
+func Printf(format string, args ...interface{}) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := s.Stdout.Write([]byte(fmt.Sprintf(format, args...)))
+		return err
+	})
+}
+
+// Read reads data from r and writes it to the pipe's stdout.
+func Read(r io.Reader) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := io.Copy(s.Stdout, r)
+		return err
+	})
+}
+
+// Write writes to w the data read from the pipe's stdin.
+func Write(w io.Writer) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := io.Copy(w, s.Stdin)
+		return err
+	})
+}
+
+// Discard reads data from the pipe's stdin and discards it.
+func Discard() Pipe {
+	return Write(ioutil.Discard)
+}
+
+// Tee reads data from the pipe's stdin and writes it both to
+// the pipe's stdout and to w.
+func Tee(w io.Writer) Pipe {
+	return TaskFunc(func(s *State) error {
+		_, err := io.Copy(w, io.TeeReader(s.Stdin, s.Stdout))
+		return err
+	})
+}
+
+// ReadFile reads data from the file at path and writes it to the
+// pipe's stdout.
+func ReadFile(path string) Pipe {
+	return TaskFunc(func(s *State) error {
+		file, err := os.Open(s.Path(path))
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(s.Stdout, file)
+		file.Close()
+		return err
+	})
+}
+
+// WriteFile writes to the file at path the data read from the
+// pipe's stdin. If the file doesn't exist, it is created with perm.
+func WriteFile(path string, perm os.FileMode) Pipe {
+	return TaskFunc(func(s *State) error {
+		file, err := os.OpenFile(s.Path(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(file, s.Stdin)
+		return firstErr(err, file.Close())
+	})
+}
+
+// AppendFile append to the end of the file at path the data read
+// from the pipe's stdin. If the file doesn't exist, it is created
+// with perm.
+func AppendFile(path string, perm os.FileMode) Pipe {
+	return TaskFunc(func(s *State) error {
+		file, err := os.OpenFile(s.Path(path), os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(file, s.Stdin)
+		return firstErr(err, file.Close())
+	})
+}
+
+// TeeWriteFile reads data from the pipe's stdin and writes it both to
+// the pipe's stdout and to the file at path. If the file doesn't
+// exist, it is created with perm.
+func TeeWriteFile(path string, perm os.FileMode) Pipe {
+	return TaskFunc(func(s *State) error {
+		file, err := os.OpenFile(s.Path(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(file, io.TeeReader(s.Stdin, s.Stdout))
+		return firstErr(err, file.Close())
+	})
+}
+
+// TeeAppendFile reads data from the pipe's stdin and writes it both to
+// the pipe's stdout and to the file at path. If the file doesn't
+// exist, it is created with perm.
+func TeeAppendFile(path string, perm os.FileMode) Pipe {
+	return TaskFunc(func(s *State) error {
+		file, err := os.OpenFile(s.Path(path), os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(file, io.TeeReader(s.Stdin, s.Stdout))
+		return firstErr(err, file.Close())
+	})
+}
+
+// Replace filters lines read from the pipe's stdin and writes
+// the returned values to stdout.
+func Replace(f func(line []byte) []byte) Pipe {
+	return TaskFunc(func(s *State) error {
+		r := bufio.NewReader(s.Stdin)
+		for {
+			line, err := r.ReadBytes('\n')
+			if len(line) > 0 {
+				line := f(line)
+				if len(line) > 0 {
+					_, err := s.Stdout.Write(line)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+		panic("unreachable")
+	})
+}
+
+// Filter filters lines read from the pipe's stdin so that only those
+// for which f is true are written to the pipe's stdout.
+// The line provided to f has '\n' and '\r' trimmed.
+func Filter(f func(line []byte) bool) Pipe {
+	return Replace(func(line []byte) []byte {
+		if f(bytes.TrimRight(line, "\r\n")) {
+			return line
+		}
+		return nil
+	})
+}
+
+// RenameFile renames the file fromPath as toPath.
+func RenameFile(fromPath, toPath string) Pipe {
+	// Register it as a task function so that within scripts
+	// it holds until all the preceding flushing is done.
+	return TaskFunc(func(s *State) error {
+		return os.Rename(s.Path(fromPath), s.Path(toPath))
+	})
+}


### PR DESCRIPTION
**Description**

- Add not owned file checker

This check is enabled when the `EXPERIMENTAL_CHECKS="notowned"` is specified. You can also define `NOT_OWNED_CHECKER_SKIP_PATTERNS="*"`. As a result, the `*` pattern from the CODEOWNERS file will be ignored and you will see not owned files unless a later match takes precedence. It's useful because often we have default owners entry 
```
# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2
```

but this should be a rare case that default owners are assigned.