### PR TITLE
Remove checking team permission as it is not working properly

### DIFF
--- a/internal/check/valid_owner.go
+++ b/internal/check/valid_owner.go
@@ -152,21 +152,8 @@ func (v *ValidOwnerChecker) validateTeam(ctx context.Context, name string) *vali
 		return false
 	}
 
-	teamHasPermissions := func() bool {
-		for _, v := range allTeams {
-			if v.GetPermission() != "pull" {
-				return true
-			}
-		}
-		return false
-	}
-
 	if !teamExists() {
 		return &validateError{fmt.Sprintf("Team %q does not exist in organization %q or has no permissions associated with the repository.", team, org), Warning, false}
-	}
-
-	if !teamHasPermissions() {
-		return &validateError{fmt.Sprintf("Team %q doesn't have write access to the repository.", team), Warning, false}
 	}
 
 	return nil


### PR DESCRIPTION
I described current problem with  the team permission check here:
https://github.com/mszostok/codeowners-validator/issues/21#issuecomment-599151297

For now, I'm going to delete that functionality because fixing it will increase number of calls to GitHub and also requires that use will pass the repo name when executing validator