### PR TITLE
Prepare application for GitHub Action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+**
+
+# Allow files and directories
+!/codeowners-validator

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,3 +30,12 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+dockers:
+  - dockerfile: Dockerfile
+    binaries:
+      - codeowners-validator
+    image_templates:
+      - "mszostok/codeowners-validator:latest"
+      - "mszostok/codeowners-validator:{{ .Tag }}"
+      - "mszostok/codeowners-validator:v{{ .Major }}.{{ .Minor }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,9 @@
 builds:
 - env:
   - CGO_ENABLED=0
+  hooks:
+    # Install upx first, https://github.com/upx/upx/releases
+    post: ./hack/ci/compress.sh
   goos:
   - linux
   - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Get latest CA certs & git
+FROM alpine:latest as deps
+RUN apk --update add ca-certificates
+RUN apk --update add git
+
+FROM scratch
+
+LABEL source=https://github.com/mszostok/codeowners-validator.git
+
+COPY ./codeowners-validator /codeowners-validator
+
+COPY --from=deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=deps /usr/bin/git /usr/bin/git
+COPY --from=deps /usr/bin/xargs  /usr/bin/xargs
+COPY --from=deps /lib /lib
+COPY --from=deps /usr/lib /usr/lib
+
+CMD ["/codeowners-validator"]
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,56 @@ You can install `codeowners-validator` with `env GO111MODULE=on go get -u github
 
 This will put `codeowners-validator` in `$(go env GOPATH)/bin`
 
+## Usage
+
+#### Docker
+
+```bash
+export GH_TOKEN=<your_token>
+docker run --rm -v $(pwd):/repo -w /repo \
+  -e REPOSITORY_PATH="." \
+  -e GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
+  -e EXPERIMENTAL_CHECKS="notowned" \
+  -e OWNER_CHECKER_REPOSITORY="org-name/rep-name" \
+  mszostok/codeowners-validator:v0.4.0
+```
+
+#### Command line
+
+```bash
+export GH_TOKEN=<your_token>
+env REPOSITORY_PATH="." \
+    GITHUB_ACCESS_TOKEN="$GH_TOKEN" \
+    EXPERIMENTAL_CHECKS="notowned" \
+    OWNER_CHECKER_REPOSITORY="org-name/rep-name" \
+  codeowners-validator
+```
+
+#### GitHub Action
+
+Coming soon 😎 Stay tuned!
+
+
+Check the [Configuration](#configuration) section for more info on how to enable and configure given checks.
+
+## Configuration
+
+Use the following environment variables to configure the application:
+
+| Name | Default | Description |
+|-----|:--------|:------------|
+| <tt>REPOSITORY_PATH</tt> <b>*</b> | | The repository path to your repository on your local machine. |
+| <tt>GITHUB_ACCESS_TOKEN</tt>| | The GitHub access token. Instruction for creating a token can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token). If not provided then validating owners functionality could not work properly, e.g. you can reach the API calls quota or if you are setting GitHub Enterprise base URL then an unauthorized error can occur. |
+| <tt>GITHUB_BASE_URL</tt>| https://api.github.com/ | The GitHub base URL for API requests. Defaults to the public GitHub API, but can be set to a domain endpoint to use with GitHub Enterprise. |
+| <tt>GITHUB_UPLOAD_URL</tt> | https://uploads.github.com/ | The GitHub upload URL for uploading files. <br> <br>It is taken into account only when the `GITHUB_BASE_URL` is also set. If only the `GITHUB_BASE_URL` is provided then this parameter defaults to the `GITHUB_BASE_URL` value. |
+| <tt>CHECKS</tt>| - |  The list of checks that will be executed. By default, all checks are executed. Possible values: `files`,`owners`,`duppatterns` |
+| <tt>EXPERIMENTAL_CHECKS</tt> | - | The comma-separated list of experimental checks that should be executed. By default, all experimental checks are turned off. Possible values: `notowned`.|
+| <tt>CHECK_FAILURE_LEVEL</tt> | `warning` | Defines the level on which the application should treat check issues as failures. Defaults to `warning`, which treats both errors and warnings as failures, and exits with error code 3. Possible values are `error` and `warning`. |
+| <tt>OWNER_CHECKER_REPOSITORY</tt>  <b>*</b>| | The owner and repository name separated by slash. For example, gh-codeowners/codeowners-samples. Used to check if GitHub owner is in the given organization. |
+| <tt>NOT_OWNED_CHECKER_SKIP_PATTERNS</tt>| - | The comma-separated list of patterns that should be ignored by `not-owned-checker`. For example, you can specify `*` and as a result, the `*` pattern from the **CODEOWNERS** file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. `*       @global-owner1 @global-owner2` |
+
+ <b>*</b> - Required
+
 ## Checks
 
 The following checks are enabled by default:
@@ -65,25 +115,7 @@ The experimental checks are disabled by default:
 
 To enable experimental check set `EXPERIMENTAL_CHECKS=notowned` environment variable. 
 
-Check the [Usage](#usage) section for more info on how to enable and configure given checks.
-
-## Usage
-
-Use the following environment variables to configure the application:
-
-| Name | Default | Description |
-|-----|:--------|:------------|
-| <tt>REPOSITORY_PATH</tt> <b>*</b> | | The repository path to your repository on your local machine. |
-| <tt>GITHUB_ACCESS_TOKEN</tt>| | The GitHub access token. Instruction for creating a token can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token). If not provided then validating owners functionality could not work properly, e.g. you can reach the API calls quota or if you are setting GitHub Enterprise base URL then an unauthorized error can occur. |
-| <tt>GITHUB_BASE_URL</tt>| https://api.github.com/ | The GitHub base URL for API requests. Defaults to the public GitHub API, but can be set to a domain endpoint to use with GitHub Enterprise. |
-| <tt>GITHUB_UPLOAD_URL</tt> | https://uploads.github.com/ | The GitHub upload URL for uploading files. <br> <br>It is taken into account only when the `GITHUB_BASE_URL` is also set. If only the `GITHUB_BASE_URL` is provided then this parameter defaults to the `GITHUB_BASE_URL` value. |
-| <tt>CHECKS</tt>| - |  The list of checks that will be executed. By default, all checks are executed. Possible values: `files`,`owners`,`duppatterns` |
-| <tt>EXPERIMENTAL_CHECKS</tt> | - | The comma-separated list of experimental checks that should be executed. By default, all experimental checks are turned off. Possible values: `notowned`.|
-| <tt>CHECK_FAILURE_LEVEL</tt> | `warning` | Defines the level on which the application should treat check issues as failures. Defaults to `warning`, which treats both errors and warnings as failures, and exits with error code 3. Possible values are `error` and `warning`. |
-| <tt>OWNER_CHECKER_REPOSITORY</tt>  <b>*</b>| | The owner and repository name separated by slash. For example, gh-codeowners/codeowners-samples. Used to check if GitHub owner is in the given organization. |
-| <tt>NOT_OWNED_CHECKER_SKIP_PATTERNS</tt>| - | The comma-separated list of patterns that should be ignored by `not-owned-checker`. For example, you can specify `*` and as a result, the `*` pattern from the **CODEOWNERS** file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. `*       @global-owner1 @global-owner2` |
-
- <b>*</b> - Required
+Check the [Configuration](#configuration) section for more info on how to enable and configure given checks.
 
 #### Exit status codes
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Use the following environment variables to configure the application:
 | <tt>CHECKS</tt>| - |  The list of checks that will be executed. By default, all checks are executed. Possible values: `files`,`owners`,`duppatterns` |
 | <tt>EXPERIMENTAL_CHECKS</tt> | - | The comma-separated list of experimental checks that should be executed. By default, all experimental checks are turned off. Possible values: `notowned`.|
 | <tt>CHECK_FAILURE_LEVEL</tt> | `warning` | Defines the level on which the application should treat check issues as failures. Defaults to `warning`, which treats both errors and warnings as failures, and exits with error code 3. Possible values are `error` and `warning`. |
-| <tt>OWNER_CHECKER_ORGANIZATION_NAME</tt>  <b>*</b>| | The organization name where the repository is created. Used to check if GitHub owner is in the given organization. |
+| <tt>OWNER_CHECKER_REPOSITORY</tt>  <b>*</b>| | The owner and repository name separated by slash. For example, gh-codeowners/codeowners-samples. Used to check if GitHub owner is in the given organization. |
 | <tt>NOT_OWNED_CHECKER_SKIP_PATTERNS</tt>| - | The comma-separated list of patterns that should be ignored by `not-owned-checker`. For example, you can specify `*` and as a result, the `*` pattern from the **CODEOWNERS** file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. `*       @global-owner1 @global-owner2` |
 
  <b>*</b> - Required

--- a/hack/ci/compress.sh
+++ b/hack/ci/compress.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Inspired by https://liam.sh/post/makefiles-for-go-projects
+
+# standard bash error handling
+set -o nounset # treat unset variables as an error and exit immediately.
+set -o errexit # exit immediately when a command fails.
+set -E         # needs to be set if we want the ERR trap
+
+readonly CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+readonly ROOT_PATH=$( cd "${CURRENT_DIR}/../.." && pwd )
+readonly GOLANGCI_LINT_VERSION="v1.23.8"
+
+source "${CURRENT_DIR}/utilities.sh" || { echo 'Cannot load CI utilities.'; exit 1; }
+
+# This will find all files (not symlinks) with the executable bit set:
+# https://apple.stackexchange.com/a/116371
+binariesToCompress=$(find "${ROOT_PATH}/dist" -perm +111 -type f)
+
+shout "Staring compression for: \n$binariesToCompress"
+
+command -v upx > /dev/null || { echo 'UPX binary not found, skipping compression.'; exit 1; }
+
+# I just do not like playing with xargs ¯\_(ツ)_/¯
+for i in $binariesToCompress
+do
+  upx --brute "$i"
+done

--- a/internal/check/not_owned_file.go
+++ b/internal/check/not_owned_file.go
@@ -7,12 +7,12 @@ import (
 	"path"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
+	ctxutil "github.com/mszostok/codeowners-validator/internal/context"
 	"github.com/mszostok/codeowners-validator/pkg/codeowners"
+
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"gopkg.in/pipe.v2"
-
-	ctxutil "github.com/mszostok/codeowners-validator/internal/context"
 )
 
 type NotOwnedFileConfig struct {
@@ -104,6 +104,8 @@ func (c *NotOwnedFile) AppendToGitignoreFile(repoDir string, patterns []string) 
 	defer f.Close()
 
 	content := strings.Builder{}
+	// ensure we are starting from new line
+	content.WriteString("\n")
 	for _, p := range patterns {
 		content.WriteString(fmt.Sprintf("%s\n", p))
 	}

--- a/internal/check/valid_owner_error.go
+++ b/internal/check/valid_owner_error.go
@@ -3,8 +3,8 @@ package check
 import "fmt"
 
 type validateError struct {
-	msg              string
-	rateLimitReached bool
+	msg       string
+	permanent bool
 }
 
 func newValidateError(format string, a ...interface{}) *validateError {
@@ -13,7 +13,7 @@ func newValidateError(format string, a ...interface{}) *validateError {
 	}
 }
 
-func (err *validateError) RateLimitReached() *validateError {
-	err.rateLimitReached = true
+func (err *validateError) AsPermanent() *validateError {
+	err.permanent = true
 	return err
 }

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -1,0 +1,13 @@
+package envconfig
+
+import (
+	"os"
+
+	"github.com/vrischmann/envconfig"
+)
+
+// Init the given config. Supports also envs prefix if set.
+func Init(conf interface{}) error {
+	envPrefix := os.Getenv("ENVS_PREFIX")
+	return envconfig.InitWithPrefix(conf, envPrefix)
+}

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -39,7 +39,11 @@ func Checks(ctx context.Context, enabledChecks []string, experimentalChecks []st
 			return nil, errors.Wrap(err, "while creating GitHub client")
 		}
 
-		checks = append(checks, check.NewValidOwner(cfg.OwnerChecker, ghClient))
+		owners, err := check.NewValidOwner(cfg.OwnerChecker, ghClient)
+		if err != nil {
+			return nil, errors.Wrap(err, "while enabling 'owners' checker")
+		}
+		checks = append(checks, owners)
 	}
 
 	expChecks, err := loadExperimentalChecks(experimentalChecks)

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/mszostok/codeowners-validator/internal/check"
+	"github.com/mszostok/codeowners-validator/internal/envconfig"
 	"github.com/mszostok/codeowners-validator/internal/github"
 
 	"github.com/pkg/errors"
-	"github.com/vrischmann/envconfig"
 )
 
 // For now, it is a good enough solution to init checks. Important thing is to do not require env variables

--- a/main.go
+++ b/main.go
@@ -8,13 +8,13 @@ import (
 	"syscall"
 
 	"github.com/mszostok/codeowners-validator/internal/check"
+	"github.com/mszostok/codeowners-validator/internal/envconfig"
 	"github.com/mszostok/codeowners-validator/internal/load"
 	"github.com/mszostok/codeowners-validator/internal/runner"
 	"github.com/mszostok/codeowners-validator/pkg/codeowners"
 	"github.com/mszostok/codeowners-validator/pkg/version"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vrischmann/envconfig"
 )
 
 // Config holds the application configuration


### PR DESCRIPTION
<!--   Thank you for your contribution -->

**Description**

Changes proposed in this pull request:

- Add support for building docker images
    Such images are published when new release is created:
    - `mszostok/codeowners-validator:latest`
    - `mszostok/codeowners-validator:v{{ .Major }}.{{ .Minor }}.{{ .Patch}}`
    - `mszostok/codeowners-validator:v{{ .Major }}.{{ .Minor }}`

- Add images compression by `upx --brute`
    Thanks to that the binary size is reduced from ~10MB to ~1.9MB for each platform.
- Fix not owned file checker
    When the .gitingore has no new line then the ignored pattern was added in the same line and it was not applied by git, so we had false negative.

- Add support for defining env prefix
    This feature was need as the GitHub Actions are injecting envs with `INPUT` prefix, e.g. INPUT_CHECKS.

- ⚠️ Change query for getting org teams
    Change requires also repository name. Because of that the `OWNER_CHECKER_ORGANIZATION_NAME` env was replaced by `OWNER_CHECKER_REPOSITORY`. More information in README.md file.

    Previously we used: https://developer.github.com/v3/teams/#list-teams
    Now we are using such query: https://developer.github.com/v3/repos/#list-teams
