### PR TITLE
fix: add spacing around pipe operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ Here is the recommended way to install `codeowners-validator`:
 
 ```bash
 # binary installed into ./bin/
-curl -sfL https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh| sh -s v0.4.0
+curl -sfL https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh | sh -s v0.4.0
 
 # binary installed into $(go env GOPATH)/bin/codeowners-validator
-curl -sfL https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v0.4.0
+curl -sfL https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v0.4.0
 
 # In alpine linux (as it does not come with curl by default)
-wget -O - -q https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh| sh -s v0.4.0
+wget -O - -q https://raw.githubusercontent.com/mszostok/codeowners-validator/master/install.sh | sh -s v0.4.0
 
 # Print version. Add `--short` to print just the version number.
 codeowners-validator -v


### PR DESCRIPTION
<!--   Thank you for your contribution -->

**Description**

Changes proposed in this pull request:

- This fixes the experience for zsh users where copy pasting `http://foo| bar` escapes the pipe as `http://foo\| bar`.

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


