### PR TITLE
Add FILES_CHECKER_FAILURE_LEVEL to support warnings instead of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The experimental checks are disabled by default:
 |----------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | notowned | **[Not Owned File Checker]** <br /><br /> Reports if a given repository contain files that do not have specified owners in CODEOWNERS file. |
 
-To enable experimental check set `EXPERIMENTAL_CHECKS=notowned` environment variable. 
+To enable experimental check set `EXPERIMENTAL_CHECKS=notowned` environment variable.
 
 Check the [Configuration](#configuration) section for more info on how to enable and configure given checks.
 
@@ -128,6 +128,7 @@ Use the following environment variables to configure the application:
 | <tt>CHECKS</tt>| - |  List of checks to be executed. By default, all checks are executed. Possible values: `files`,`owners`,`duppatterns`,`syntax`. |
 | <tt>EXPERIMENTAL_CHECKS</tt> | - | The comma-separated list of experimental checks that should be executed. By default, all experimental checks are turned off. Possible values: `notowned`.|
 | <tt>CHECK_FAILURE_LEVEL</tt> | `warning` | Defines the level on which the application should treat check issues as failures. Defaults to `warning`, which treats both errors and warnings as failures, and exits with error code 3. Possible values are `error` and `warning`. |
+| <tt>FILES_CHECKER_FAILURE_LEVEL</tt> | `error` | Defines the failure level that the `files` checker emits. Defaults to `error`. Possible values are `error` and `warning`. |
 | <tt>OWNER_CHECKER_REPOSITORY</tt>  <b>*</b>| | The owner and repository name separated by slash. For example, gh-codeowners/codeowners-samples. Used to check if GitHub owner is in the given organization. |
 | <tt>OWNER_CHECKER_IGNORED_OWNERS</tt> | `@ghost`| The comma-separated list of owners that should not be validated. Example: `"@owner1,@owner2,@org/team1,example@email.com"`. |
 | <tt>NOT_OWNED_CHECKER_SKIP_PATTERNS</tt>| - | The comma-separated list of patterns that should be ignored by `not-owned-checker`. For example, you can specify `*` and as a result, the `*` pattern from the **CODEOWNERS** file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. `*       @global-owner1 @global-owner2` |
@@ -136,7 +137,7 @@ Use the following environment variables to configure the application:
 
 #### Exit status codes
 
-Application exits with different status codes which allow you to easily distinguish between error categories.  
+Application exits with different status codes which allow you to easily distinguish between error categories.
 
 | Code | Description |
 |:-----:|:------------|
@@ -146,7 +147,7 @@ Application exits with different status codes which allow you to easily distingu
 
 ## Contributing
 
-Contributions are greatly appreciated! The project follows the typical GitHub pull request model. See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.  
+Contributions are greatly appreciated! The project follows the typical GitHub pull request model. See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## Roadmap
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Defines the level on which the application should treat check issues as failures. Defaults to warning, which treats both errors and warnings as failures, and exits with error code 3. Possible values are error and warning. Default: warning"
     required: false
 
+  files_checker_failure_level:
+    description: "Defines the failure level that the files checker emits. Possible values are error and warning. Default: error"
+    required: false
+
   not_owned_checker_skip_patterns:
     description: "The comma-separated list of patterns that should be ignored by not-owned-checker. For example, you can specify * and as a result, the * pattern from the CODEOWNERS file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. * @global-owner1 @global-owner2"
     required: false

--- a/internal/check/file_exists_test.go
+++ b/internal/check/file_exists_test.go
@@ -163,7 +163,7 @@ func TestFileExists(t *testing.T) {
 
 			initFSStructure(t, tmp, tc.paths)
 
-			fchecker := check.NewFileExist()
+			fchecker := check.NewFileExist(check.FileExistsConfig{})
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 			defer cancel()
@@ -198,7 +198,7 @@ func TestFileExistCheckFileSystemFailure(t *testing.T) {
 	defer cancel()
 
 	// when
-	out, err := check.NewFileExist().Check(ctx, in)
+	out, err := check.NewFileExist(check.FileExistsConfig{}).Check(ctx, in)
 
 	// then
 	require.Error(t, err)

--- a/internal/check/package_test.go
+++ b/internal/check/package_test.go
@@ -19,7 +19,7 @@ func TestRespectingCanceledContext(t *testing.T) {
 
 	checkers := []check.Checker{
 		check.NewDuplicatedPattern(),
-		check.NewFileExist(),
+		check.NewFileExist(check.FileExistsConfig{}),
 		check.NewValidSyntax(),
 		check.NewNotOwnedFile(check.NotOwnedFileConfig{}),
 		must(check.NewValidOwner(check.ValidOwnerConfig{Repository: "org/repo"}, nil)),

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -26,7 +26,13 @@ func Checks(ctx context.Context, enabledChecks []string, experimentalChecks []st
 	}
 
 	if isEnabled(enabledChecks, "files") {
-		checks = append(checks, check.NewFileExist())
+		var cfg struct {
+			FilesChecker check.FileExistsConfig
+		}
+		if err := envconfig.Init(&cfg); err != nil {
+			return nil, errors.Wrapf(err, "while loading config for %s", "files")
+		}
+		checks = append(checks, check.NewFileExist(cfg.FilesChecker))
 	}
 
 	if isEnabled(enabledChecks, "owners") {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- These failures cause no real issues, they're just indicative of potential misconfigurations and/or are purely informative
- This allows the tool to report results while not failing

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


