### PR TITLE
spelling: github

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,6 @@ Contributions are greatly appreciated! The project follows the typical GitHub pu
 
 ## Roadmap
 
-The [codeowners-validator roadmap uses Github milestones](https://github.com/mszostok/codeowners-validator/milestone/1) to track the progress of the project.
+The [codeowners-validator roadmap uses GitHub milestones](https://github.com/mszostok/codeowners-validator/milestone/1) to track the progress of the project.
 
 They are sorted with priority. First are most important.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "GitHub CODEOWNERS Validator"
-description: "Github action to ensure the correctness of your CODEOWNERS file."
+description: "GitHub action to ensure the correctness of your CODEOWNERS file."
 author: "szostok.mateusz@gmail.com"
 
 inputs:

--- a/internal/check/valid_owner.go
+++ b/internal/check/valid_owner.go
@@ -115,14 +115,14 @@ func isEmailAddress(s string) bool {
 	return err == nil
 }
 
-func isGithubTeam(s string) bool {
+func isGitHubTeam(s string) bool {
 	hasPrefix := strings.HasPrefix(s, "@")
 	containsSlash := strings.Contains(s, "/")
 	split := strings.SplitN(s, "/", 3) // 3 is enough to confirm that is invalid + will not overflow the buffer
 	return hasPrefix && containsSlash && len(split) == 2 && len(split[1]) > 0
 }
 
-func isGithubUser(s string) bool {
+func isGitHubUser(s string) bool {
 	return !strings.Contains(s, "/") && strings.HasPrefix(s, "@")
 }
 
@@ -133,9 +133,9 @@ func (v *ValidOwner) isIgnoredOwner(name string) bool {
 
 func (v *ValidOwner) selectValidateFn(name string) func(context.Context, string) *validateError {
 	switch {
-	case isGithubUser(name):
-		return v.validateGithubUser
-	case isGithubTeam(name):
+	case isGitHubUser(name):
+		return v.validateGitHubUser
+	case isGitHubTeam(name):
 		return v.validateTeam
 	case isEmailAddress(name):
 		// TODO(mszostok): try to check if e-mail really exists
@@ -266,7 +266,7 @@ func (v *ValidOwner) validateTeam(ctx context.Context, name string) *validateErr
 	return nil
 }
 
-func (v *ValidOwner) validateGithubUser(ctx context.Context, name string) *validateError {
+func (v *ValidOwner) validateGitHubUser(ctx context.Context, name string) *validateError {
 	if v.orgMembers == nil { //TODO(mszostok): lazy init, make it more robust.
 		if err := v.initOrgListMembers(ctx); err != nil {
 			return newValidateError("Cannot initialize organization member list: %v", err).AsPermanent()

--- a/internal/check/valid_owner_export_test.go
+++ b/internal/check/valid_owner_export_test.go
@@ -1,5 +1,5 @@
 package check
 
 func IsValidOwner(owner string) bool {
-	return isEmailAddress(owner) || isGithubUser(owner) || isGithubTeam(owner)
+	return isEmailAddress(owner) || isGitHubUser(owner) || isGitHubTeam(owner)
 }

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -32,13 +32,13 @@ func Checks(ctx context.Context, enabledChecks []string, experimentalChecks []st
 	if isEnabled(enabledChecks, "owners") {
 		var cfg struct {
 			OwnerChecker check.ValidOwnerConfig
-			GitHub       github.ClientConfig
+			Github       github.ClientConfig
 		}
 		if err := envconfig.Init(&cfg); err != nil {
 			return nil, errors.Wrapf(err, "while loading config for %s", "owners")
 		}
 
-		ghClient, err := github.NewClient(ctx, cfg.GitHub)
+		ghClient, err := github.NewClient(ctx, cfg.Github)
 		if err != nil {
 			return nil, errors.Wrap(err, "while creating GitHub client")
 		}

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -32,13 +32,13 @@ func Checks(ctx context.Context, enabledChecks []string, experimentalChecks []st
 	if isEnabled(enabledChecks, "owners") {
 		var cfg struct {
 			OwnerChecker check.ValidOwnerConfig
-			Github       github.ClientConfig
+			GitHub       github.ClientConfig
 		}
 		if err := envconfig.Init(&cfg); err != nil {
 			return nil, errors.Wrapf(err, "while loading config for %s", "owners")
 		}
 
-		ghClient, err := github.NewClient(ctx, cfg.Github)
+		ghClient, err := github.NewClient(ctx, cfg.GitHub)
 		if err != nil {
 			return nil, errors.Wrap(err, "while creating GitHub client")
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix spelling of brand `GitHub`