### PR TITLE
Handle internal err,  report issue with empty CODEOWNERS or git dirty state

### DIFF
--- a/internal/printer/testdata/TestTTYPrinterPrintCheckResult/Should_print_all_reported_issues.golden.txt
+++ b/internal/printer/testdata/TestTTYPrinterPrintCheckResult/Should_print_all_reported_issues.golden.txt
@@ -3,3 +3,4 @@
     [war] line 2020: Simulate warning in line 2020
     [err] Error without line number
     [war] Warning without line number
+    [Internal Error] some check internal error

--- a/internal/printer/tty_test.go
+++ b/internal/printer/tty_test.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -43,7 +44,7 @@ func TestTTYPrinterPrintCheckResult(t *testing.T) {
 					Message:  "Warning without line number",
 				},
 			},
-		})
+		}, errors.New("some check internal error"))
 		// then
 		g := goldie.New(t, goldie.WithNameSuffix(".golden.txt"))
 		g.Assert(t, t.Name(), buff.Bytes())
@@ -60,7 +61,7 @@ func TestTTYPrinterPrintCheckResult(t *testing.T) {
 		// when
 		tty.PrintCheckResult("Foo Checker", time.Second, check.Output{
 			Issues: nil,
-		})
+		}, nil)
 
 		// then
 		g := goldie.New(t, goldie.WithNameSuffix(".golden.txt"))


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Handle internal checks errors
  Previously they were only logged, now there are printed to check results and proper exit code is also set.
  Instead of:
  ```
  time="2022-02-27T09:21:01Z" level=error msg="while executing checker [Experimental] Not Owned File Checker: 1 error occurred:\n\t* fatal: No pathspec was given. Which files should I remove?\n: command \"xargs\": exit status 123\n\n" service="check:runner"
  ```
  We have:

    ```
    ==> Executing [Experimental] Not Owned File Checker (23.312587ms)
        [Internal Error] No pathspec was given. Which files should I remove?\n: command \"xargs\": exit status 123
    
    1 check(s) executed, 1 failure(s)
    exit status 3
    ```
- Report issue with empty CODEOWNERS 
    ```
    ==> Executing [Experimental] Not Owned File Checker (23.312587ms)
        [err] The CODEOWNERS file is empty. The files in the repository don't have any owner.
    
    1 check(s) executed, 1 failure(s)
    exit status 3
    ```
- Report or git dirty state
    ```
    ==> Executing [Experimental] Not Owned File Checker (23.312587ms)
        [err] git state is dirty: commit all changes before executing this check
    
    1 check(s) executed, 1 failure(s)
    exit status 3
    ```

**Related issue(s)**

Fix https://github.com/mszostok/codeowners-validator/issues/126


